### PR TITLE
Updated function to remove archived entities

### DIFF
--- a/backend/lambda/deleteVolunteer/lambda_function.py
+++ b/backend/lambda/deleteVolunteer/lambda_function.py
@@ -21,7 +21,10 @@ def lambda_handler(event, context):
         )
 
         cur = con.cursor()
-        query = "DELETE FROM volunteers WHERE rejected_date IS NOT NULL AND status ='Rejected' AND EXTRACT(DAY FROM (current_date at time zone 'UTC') - rejected_date) >= 30 RETURNING *"
+        query = """DELETE FROM volunteers WHERE rejected_date IS NOT NULL AND status ='Rejected' AND EXTRACT(DAY FROM (current_date at time zone 'UTC') - rejected_date) >= 30 RETURNING *;
+                DELETE FROM volunteers WHERE is_active = FALSE AND EXTRACT(DAY FROM (current_date at time zone 'UTC') - updated_at) >= 30 RETURNING *;
+                DELETE FROM projects WHERE is_active = FALSE AND EXTRACT(DAY FROM (current_date at time zone 'UTC') - updated_at) >= 30 RETURNING *;
+                DELETE FROM pwas WHERE is_active = FALSE AND EXTRACT(DAY FROM (current_date at time zone 'UTC') - updated_at) >= 30 RETURNING *;"""
         cur.execute(query)
         con.commit()
 


### PR DESCRIPTION
Currently removes PWAs, Volunteers & Projects.

Does not remove Staffs at the moment (need to test more in prod server & am unsure if that's the user stories)
Also, the lambda function currently is still named deleteVolunteer, unsure if it's an issue