### PR TITLE
add title attribute for very long notifications

### DIFF
--- a/frontend/components/dashboard/NotificationItem.vue
+++ b/frontend/components/dashboard/NotificationItem.vue
@@ -6,7 +6,7 @@
 
     <v-list-item-content>
       <v-list-item-title class="font-weight-bold pb-1">
-        <NuxtLink class="black--text notification-link" :to="link">{{ notification.message }}</NuxtLink>
+        <p :title="notification.message"><NuxtLink class="black--text notification-link" :to="link">{{ notification.message }}</NuxtLink></p>
       </v-list-item-title>
       <v-list-item-subtitle>
         {{ $moment(notification.created_at.slice(0,10)).format('DD MMM YYYY') }}


### PR DESCRIPTION
notification with long message will be cut out.

I include the message in a title attribute so it will show full message when you hover